### PR TITLE
Fix for second-level domains in MX row

### DIFF
--- a/domainaware
+++ b/domainaware
@@ -87,10 +87,9 @@ def crazy_twist(crazy_row):
         twist_row['Country'] = convert_country(crazy_row["Country-A"])
 
     # Sometimes the URLCrazy MX row is actually the TLD row :\
-    if twist_row["MX"] == twist_row["Domain"].split(".")[-1]:
-        twist_row["MX"] = ''
-    # Cater for TLDs that contain "." (e.g. "com.au")
-    if twist_row["MX"] == twist_row["Domain"].split(".", 1)[1]:
+    if twist_row["MX"] == twist_row["Domain"].split(".")[-1] \
+    or twist_row["MX"] == twist_row["Domain"].split(".",1)[-1] \
+    or twist_row["MX"] == twist_row["Domain"].split(".",2)[-1]:
         twist_row["MX"] = ''
 
     return twist_row

--- a/domainaware
+++ b/domainaware
@@ -89,6 +89,9 @@ def crazy_twist(crazy_row):
     # Sometimes the CrazyURL MX row is actually the TLD row :\
     if twist_row["MX"] == twist_row["Domain"].split(".")[-1]:
         twist_row["MX"] = ''
+    # Cater for TLDs that contain "." (e.g. "com.au")
+    if twist_row["MX"] == twist_row["Domain"].split(".", 1)[1]:
+        twist_row["MX"] = ''
 
     return twist_row
 

--- a/domainaware
+++ b/domainaware
@@ -86,7 +86,7 @@ def crazy_twist(crazy_row):
     if crazy_row['Country-A']:
         twist_row['Country'] = convert_country(crazy_row["Country-A"])
 
-    # Sometimes the CrazyURL MX row is actually the TLD row :\
+    # Sometimes the URLCrazy MX row is actually the TLD row :\
     if twist_row["MX"] == twist_row["Domain"].split(".")[-1]:
         twist_row["MX"] = ''
     # Cater for TLDs that contain "." (e.g. "com.au")


### PR DESCRIPTION
Sometimes the MX row contains TLD row in second-level domain format (e.g. "com.au"). This causes a lot of false positives in the results, as MX row remains populated.