### PR TITLE
Remove deprecated 'U' mode from open()

### DIFF
--- a/domainaware
+++ b/domainaware
@@ -203,7 +203,7 @@ def find_new_domains(tool_paths, my_domains_path, known_domains_path,
         for row in known_domains_csv:
             known_domains.add(row["Domain"])
 
-    with open(my_domains_path, 'rU') as my_domains:
+    with open(my_domains_path, 'r') as my_domains:
         for my_domain in my_domains:
             my_domain = my_domain.strip().lower()
             known_domains.add(my_domain)


### PR DESCRIPTION
Script fails to run under Python 3.11 due to the use of the now removed `U` mode in `open()`. This mode had no effect in Python 3 and was included only to aid porting from Python 2.